### PR TITLE
Update comboTreePlugin.js

### DIFF
--- a/comboTreePlugin.js
+++ b/comboTreePlugin.js
@@ -377,7 +377,7 @@
         if (searchText != ""){
             this._elemItemsTitle.hide();
             this._elemItemsTitle.siblings("span.comboTreeParentPlus").hide();
-            list = this._elemItems.find("span:icontains('" + searchText + "')").each(function (i, elem) {
+            list = this._elemItems.find("span\\:icontains('" + searchText + "')").each(function (i, elem) {
                 $(this).show();
                 $(this).siblings("span.comboTreeParentPlus").show();
             });    


### PR DESCRIPTION
From time to time the following error occurs: 'unrecognized expression: unsupported pseudo: icontains'.
According this [post](https://stackoverflow.com/questions/16077280/uncaught-error-syntax-error-unrecognized-expression-unsupported-pseudo/16077843) the reason is a not escaped symbol ':' on  
row 380.