### PR TITLE
Obey cascadeSelect configuration in setSelection()

### DIFF
--- a/comboTreePlugin.js
+++ b/comboTreePlugin.js
@@ -579,7 +579,12 @@
 
               this._selectedItems.push(selectedItem);
               this._selectedItem = selectedItem;
-              $(selectedItemElem).find("input").prop('checked', true);
+              // If cascadeSelect is true, check all children, otherwise just check this item
+              if (this.options.cascadeSelect) {
+                $(selectedItemElem).find("input").prop('checked', true);
+              } else {
+                $(selectedItemElem).find("input:first").prop('checked', true);
+              }
             }
           }
         }


### PR DESCRIPTION
`setSelection` always finds child input elements and changes the `checked` property to `true`, even if `cascadeSelect` is `false`
in the configuration. This causes some unexpected behaviour when the setSelection() method is used manually and only the exact node is expected to be selected.

This PR checks configuration first and if `cascadeSelect` is `false`, just changes the :first input element.