### PR TITLE
add feature isolated "selectable"

### DIFF
--- a/comboTreePlugin.js
+++ b/comboTreePlugin.js
@@ -18,7 +18,8 @@
       selected: [],
       collapse: false,
       selectableLastNode: false,
-      withSelectAll: false
+      withSelectAll: false,
+      isolatedSelectable: false
     };
 
   // LIFE CYCLE
@@ -134,9 +135,12 @@
     var itemHtml = "",
       isThereSubs = sourceItem.hasOwnProperty("subs"),
         collapse = sourceItem.hasOwnProperty("collapse") ? sourceItem.hasOwnProperty("collapse") : false;
-    let isSelectable = (sourceItem.isSelectable === undefined ? true : sourceItem.isSelectable),
-      selectableClass = (isSelectable || isThereSubs) ? 'selectable' : 'not-selectable',
-      selectableLastNode = (this.options.selectableLastNode!==undefined && isThereSubs) ? this.options.selectableLastNode : false;
+    let isSelectable = (sourceItem.isSelectable === undefined ? true : sourceItem.isSelectable);
+    let selectableClass = (isSelectable || isThereSubs) ? 'selectable' : 'not-selectable';
+    if (this.options.isolatedSelectable) {
+      selectableClass = isSelectable ? 'selectable' : 'not-selectable';
+    }
+    let selectableLastNode = (this.options.selectableLastNode !== undefined && isThereSubs) ? this.options.selectableLastNode : false;
 
     itemHtml += '<LI id="' + this.comboTreeId + 'Li' + sourceItem.id + '" class="ComboTreeItem' + (isThereSubs?'Parent':'Chlid') + '"> ';
 


### PR DESCRIPTION
this PR offers the feature "isolated selectable".
now when parent is set  "isSelectable" to false and child set to "isSelectable" to true, parent node's class has been set class to selectable.
but I want to set parent's class to according to parent's attribute.
so I've made this PR.
please check.

data is this.
![スクリーンショット 2022-10-07 21 01 10](https://user-images.githubusercontent.com/115578/194550318-9fea5d50-afa9-448d-b8a9-07c6dcb6ed2a.png)
before:
(watch Birds element and Birds is "selectable")

https://user-images.githubusercontent.com/115578/194550450-9f3654dd-c1c8-4eb1-8eb9-95bace6b8050.mov

with this PR: 


https://user-images.githubusercontent.com/115578/194550517-bda202bc-5313-4222-9e9f-6a7d1514238a.mov

