### PR TITLE
subs array now handles empty array sets properly

### DIFF
--- a/comboTreePlugin.js
+++ b/comboTreePlugin.js
@@ -159,7 +159,10 @@
 
   ComboTree.prototype.createSourceItemHTML = function (sourceItem) {
     let itemHtml = "";
-    const isThereSubs = sourceItem.hasOwnProperty("subs");
+    let isThereSubs = false;
+    if (sourceItem.hasOwnProperty("subs")) {
+        isThereSubs = sourceItem.subs.length > 0;
+    }
     const collapse = sourceItem.hasOwnProperty("collapse")
       ? sourceItem.hasOwnProperty("collapse")
       : false;

--- a/comboTreePlugin.js
+++ b/comboTreePlugin.js
@@ -159,10 +159,7 @@
 
   ComboTree.prototype.createSourceItemHTML = function (sourceItem) {
     let itemHtml = "";
-    let isThereSubs = false;
-    if (sourceItem.hasOwnProperty("subs")) {
-        isThereSubs = sourceItem.subs.length > 0;
-    }
+    let isThereSubs = sourceItem.hasOwnProperty("subs") ? (sourceItem.subs.length > 0) : false;
     const collapse = sourceItem.hasOwnProperty("collapse")
       ? sourceItem.hasOwnProperty("collapse")
       : false;


### PR DESCRIPTION
If the subs array set is empty, don't acknowledge the subs child and create unnecessary HTML.